### PR TITLE
Added podspec

### DIFF
--- a/ODRefreshControl.podspec
+++ b/ODRefreshControl.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name     = 'ODRefreshControl'
+  s.version  = '0.0.1'
+  s.license  = 'MIT'
+  s.summary  = "A pull down to refresh control like the one in Apple's iOS6 Mail App."
+  s.homepage = 'https://github.com/Sephiroth87/ODRefreshControl'
+  s.author   = 'Sephiroth87'
+  s.source   = { :git => 'https://github.com/Sephiroth87/ODRefreshControl.git', :commit => '464f80c793' }
+
+  s.description = 'ODRefreshControl is a "pull down to refresh" control for UIScrollView,' \
+                  'like the one Apple introduced in iOS6, but available to anyone from iOS4 and up.'
+  s.platform    = :ios
+
+  s.source_files = 'ODRefreshControl/ODRefreshControl*.{h,m}'
+  s.clean_path   = 'Demo'
+  s.framework    = 'QuartzCore'
+
+  s.requires_arc = true
+end


### PR DESCRIPTION
I’ve recently added `ODRefreshControl` to the [CocoaPods](https://github.com/CocoaPods/CocoaPods) package manager repo.

CocoaPods is a tool for managing dependencies for OSX and iOS Xcode projects and provides a central repository for iOS/OSX libraries. This makes adding libraries to a project and updating them extremely easy and it will help users to resolve dependencies of the libraries they use.

However, `ODRefreshControl` doesn't have any version tags. I’ve added the current HEAD as version 0.0.1, but a version tag will make dependency resolution much easier.

[Semantic version](http://semver.org) tags (instead of plain commit hashes/revisions) allow for [resolution of cross-dependencies](https://github.com/CocoaPods/Specs/wiki/Cross-dependencies-resolution-example).

In case you didn’t know this yet; you can tag the current HEAD as, for instance, version 1.0.0, like so:

```
$ git tag -a 1.0.0 -m "Tag release 1.0.0"
$ git push --tags
```
