### PR TITLE
Bounce Area Background / Reduced required pull distance

### DIFF
--- a/ODRefreshControl/ODRefreshControl.m
+++ b/ODRefreshControl/ODRefreshControl.m
@@ -51,7 +51,7 @@ static inline CGFloat lerp(CGFloat a, CGFloat b, CGFloat p)
         self.scrollView = scrollView;
         
         
-        UIView *topview = [[UIView alloc] initWithFrame:CGRectMake(0,-480,320,480)];
+        UIView *topview = [[UIView alloc] initWithFrame:CGRectMake(0,-480,480,480)];
         topview.backgroundColor = [UIColor colorWithRed:226.0/255.0 green:231.0/255.0 blue:238.0/255.0 alpha:1];
         [scrollView addSubview:topview];
         


### PR DESCRIPTION
The background for the bounce area is shown both in Apple's mail and contacts app. 

If a project uses both a Navigation & toolbar, the scroll distance of 53 in landscape doesn't work. I've reduced it to 36.
