### PR TITLE
Added support for scroll views with a content inset

### DIFF
--- a/ODRefreshControl/ODRefreshControl.m
+++ b/ODRefreshControl/ODRefreshControl.m
@@ -140,7 +140,7 @@ static inline CGFloat lerp(CGFloat a, CGFloat b, CGFloat p)
     }
     
     CGFloat offset = [[change objectForKey:@"new"] CGPointValue].y + self.scrollView.contentInset.top;
-
+    
     CGFloat alpha = 1.0f;
     if ( !_refreshing )
         alpha = ( offset >= 0 ? 0 : ABS(offset)/kOpenedViewHeight);
@@ -159,7 +159,7 @@ static inline CGFloat lerp(CGFloat a, CGFloat b, CGFloat p)
             
             // Set the inset only when bouncing back and not dragging
             if (offset >= -kOpenedViewHeight && !self.scrollView.dragging) {
-                [self.scrollView setContentInset:UIEdgeInsetsMake(kOpenedViewHeight, 0, 0, 0)];
+                [self.scrollView setContentInset:self.openedInsets];
             }
         }
         return;


### PR DESCRIPTION
ODRefreshControl currently assumes a UIEdgeInsetsZero content inset. This doesn't work in the case where the scroll bar has a different contentInset (such as a table view displayed in a UINavigationController with a translucent navigation bar).
