### PR TITLE
Add optional background for scroll-above area

### DIFF
--- a/ODRefreshControl/ODRefreshControl.h
+++ b/ODRefreshControl/ODRefreshControl.h
@@ -26,6 +26,8 @@
 
 @property (nonatomic, readonly) BOOL refreshing;
 @property (nonatomic, strong) UIColor *tintColor;
+@property (nonatomic, strong) UIColor *backgroundColor;
+@property (nonatomic) BOOL showsBackground;
 @property (nonatomic, assign) UIActivityIndicatorViewStyle activityIndicatorViewStyle;
 
 - (id)initInScrollView:(UIScrollView *)scrollView;

--- a/ODRefreshControl/ODRefreshControl.m
+++ b/ODRefreshControl/ODRefreshControl.m
@@ -29,6 +29,7 @@
 @interface ODRefreshControl ()
 
 @property (nonatomic, readwrite) BOOL refreshing;
+@property (nonatomic, assign) UIView *topBackgroundView;
 @property (nonatomic, assign) UIScrollView *scrollView;
 @property (nonatomic, assign) UIEdgeInsets originalContentInset;
 
@@ -37,8 +38,11 @@
 @implementation ODRefreshControl
 
 @synthesize refreshing = _refreshing;
+@synthesize showsBackground = _showsBackground;
 @synthesize tintColor = _tintColor;
+@synthesize backgroundColor = _backgroundColor;
 
+@synthesize topBackgroundView = _topBackgroundView;
 @synthesize scrollView = _scrollView;
 @synthesize originalContentInset = _originalContentInset;
 
@@ -54,6 +58,8 @@ static inline CGFloat lerp(CGFloat a, CGFloat b, CGFloat p)
     if (self) {
         self.scrollView = scrollView;
         self.originalContentInset = scrollView.contentInset;
+
+        self.showsBackground = YES;
         
         self.autoresizingMask = UIViewAutoresizingFlexibleWidth;
         [scrollView addSubview:self];
@@ -125,6 +131,44 @@ static inline CGFloat lerp(CGFloat a, CGFloat b, CGFloat p)
 {
     _tintColor = tintColor;
     _shapeLayer.fillColor = [_tintColor CGColor];
+}
+
+- (UIColor *)backgroundColor
+{
+    if (!_backgroundColor) {
+        _backgroundColor = [UIColor colorWithRed:226.0/255.0 green:231.0/255.0 blue:238.0/255.0 alpha:1];
+    }
+    return _backgroundColor;
+}
+
+- (void)setBackgroundColor:(UIColor *)backgroundColor
+{
+    _backgroundColor = backgroundColor;
+    self.topBackgroundView.backgroundColor = _backgroundColor;
+}
+
+- (void)setShowsBackground:(BOOL)showsBackground
+{
+    _showsBackground = showsBackground;
+    if (showsBackground) {
+        [self addTopBackgroundView];
+    } else {
+        [self.topBackgroundView removeFromSuperview];
+        self.topBackgroundView = nil;
+    }
+}
+
+- (void)addTopBackgroundView
+{
+    if (self.topBackgroundView) return;
+    UIScrollView *scrollView = self.scrollView;
+
+    UIView *topBackgroundView = [[UIView alloc] initWithFrame:(CGRect){ {0, -scrollView.frame.size.height}, scrollView.frame.size}];
+    topBackgroundView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+    topBackgroundView.backgroundColor = [self backgroundColor];
+
+    [scrollView addSubview:topBackgroundView];
+    self.topBackgroundView = topBackgroundView;
 }
 
 - (void)setActivityIndicatorViewStyle:(UIActivityIndicatorViewStyle)activityIndicatorViewStyle


### PR DESCRIPTION
The background color can be customized with the refresh control's `backgroundColor` property. By default, it is a light blue color which works well with native UIKit components. The background can be disabled using the refresh control's `showsBackground` property.

I've tested this to ensure it works and rotates/resizes well on iPhone, iPhone 3.5" Retina, iPhone 4" Retina, iPad, and iPad Retina screens.

I've tried to maintain iOS 4/old-Xcode compatibility in this code, but I might have missed something. Additional comments on cleaning up my code are welcomed.
