### PR TITLE
Add support for custom frame

### DIFF
--- a/ODRefreshControl/ODRefreshControl.h
+++ b/ODRefreshControl/ODRefreshControl.h
@@ -30,6 +30,9 @@
 
 - (id)initInScrollView:(UIScrollView *)scrollView;
 
+// use custom frame
+- (id)initWithFrame:(CGRect)frame InScrollView:(UIScrollView *)scrollView;
+
 // use custom activity indicator
 - (id)initInScrollView:(UIScrollView *)scrollView activityIndicatorView:(UIView *)activity;
 

--- a/ODRefreshControl/ODRefreshControl.m
+++ b/ODRefreshControl/ODRefreshControl.m
@@ -51,9 +51,18 @@ static inline CGFloat lerp(CGFloat a, CGFloat b, CGFloat p)
     return [self initInScrollView:scrollView activityIndicatorView:nil];
 }
 
+- (id)initWithFrame:(CGRect)frame InScrollView:(UIScrollView *)scrollView {
+    self = [super initWithFrame:frame];
+    return [self initInScrollView:scrollView activityIndicatorView:nil];
+}
+
 - (id)initInScrollView:(UIScrollView *)scrollView activityIndicatorView:(UIView *)activity
 {
-    self = [super initWithFrame:CGRectMake(0, -(kTotalViewHeight + scrollView.contentInset.top), scrollView.frame.size.width, kTotalViewHeight)];
+    if (CGRectEqualToRect(self.frame, CGRectZero)) {
+        CGRect sRect = CGRectMake(0, -(kTotalViewHeight + scrollView.contentInset.top),
+                                  scrollView.frame.size.width, kTotalViewHeight);
+        self = [super initWithFrame:sRect];
+    }
     
     if (self) {
         self.scrollView = scrollView;


### PR DESCRIPTION
Add a method -(id)initWithFrame:InScrollView: in ODRefreshControl to
allow users of the class to provide a custom frame. Currently,
ODRefreshControl is assuming that the parent UITableView has vertical
UITableViewCells, which may not be the case in apps like Pulse-news,
where the UITableViewCells are layed out horizontally on the
UITableView. Add the aforementioned method to allow assigning custom
frame for the control so that it can animate properly in a horizontal
UITableView.
