### PR TITLE
When start refreshing from code, refresh control reveals itself.

### DIFF
--- a/ODRefreshControl/ODRefreshControl.m
+++ b/ODRefreshControl/ODRefreshControl.m
@@ -412,9 +412,14 @@ static inline CGFloat lerp(CGFloat a, CGFloat b, CGFloat p)
 
         CGPoint offset = self.scrollView.contentOffset;
         _ignoreInset = YES;
-        [self.scrollView setContentInset:UIEdgeInsetsMake(kOpenedViewHeight + self.originalContentInset.top, self.originalContentInset.left, self.originalContentInset.bottom, self.originalContentInset.right)];
+        [self.scrollView setContentInset:UIEdgeInsetsMake(kOpenedViewHeight + self.originalContentInset.top
+            , self.originalContentInset.left
+            , self.originalContentInset.bottom
+            , self.originalContentInset.right)];
         _ignoreInset = NO;
-        [self.scrollView setContentOffset:offset animated:NO];
+
+        offset.y = -kOpenedViewHeight;
+        [self.scrollView setContentOffset:offset animated:YES];
 
         self.refreshing = YES;
         _canRefresh = NO;


### PR DESCRIPTION
I had an issue that, when I had a populated table-view and then I started refreshing the list from code, refresh control wasn't visible. So the user wasn't aware of some network process to go behind the scenes. Now, when code refresh is invoked, the scrollView is scrolled with animation in way that refresh control is visible during refresh operation. Not sure though, it's the best way of achieving this. You probably will find a better way as an author of the component.
