### PR TITLE
UIAppearanceContainer support

### DIFF
--- a/ODRefreshControl/ODRefreshControl.h
+++ b/ODRefreshControl/ODRefreshControl.h
@@ -11,7 +11,7 @@
 #import <UIKit/UIKit.h>
 #import <QuartzCore/QuartzCore.h>
 
-@interface ODRefreshControl : UIControl {
+@interface ODRefreshControl : UIControl<UIAppearanceContainer> {
     CAShapeLayer *_shapeLayer;
     CAShapeLayer *_arrowLayer;
     CAShapeLayer *_highlightLayer;
@@ -26,7 +26,10 @@
 }
 
 @property (nonatomic, readonly) BOOL refreshing;
-@property (nonatomic, strong) UIColor *tintColor;
+@property (nonatomic, strong) UIColor *tintColor UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) UIColor *strokeColor UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) UIColor *shadowColor UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) UIColor *highlightColor UI_APPEARANCE_SELECTOR;
 @property (nonatomic, assign) UIActivityIndicatorViewStyle activityIndicatorViewStyle;
 @property (nonatomic, strong) UIColor *activityIndicatorViewColor; // iOS5 or more
 


### PR DESCRIPTION
Hi. Thanks for your library.

I had to customize the control appearance.

![Capture d e cran du Simulateur iOS 15 fe vr 2013 17 05 40](https://f.cloud.github.com/assets/54219/161282/b03150f2-7789-11e2-91a0-1fd3116189d6.png)

So I did add UIAppearanceContainer support for tintColor, strokeColor, shadowColor & highlightColor, so that I could write:

``` objc
@implementation MyViewController

+ (void)initialize
{
    id refreshControlAppearance = [ODRefreshControl appearanceWhenContainedIn:self, nil];
    [refreshControlAppearance setTintColor:[UIColor colorWithWhite:0 alpha:0.25]];
    [refreshControlAppearance setStrokeColor:[UIColor clearColor]];
    [refreshControlAppearance setHighlightColor:[UIColor clearColor]];
    [refreshControlAppearance setShadowColor:[UIColor clearColor]];
}

@end
```

Let me know if you are interested.
