### PR TITLE
Add "kTopOffset" parameter to make RefreshControl work on Apps with "translucent" header bar

### DIFF
--- a/ODRefreshControl/ODRefreshControl.m
+++ b/ODRefreshControl/ODRefreshControl.m
@@ -25,6 +25,7 @@
 #define kMinArrowRadius     5
 #define kMaxArrowRadius     7
 #define kMaxDistance        53
+#define kTopOffset          44//offset of the parent table-view (e.g. translucent header-bar)
 
 @interface ODRefreshControl ()
 
@@ -53,7 +54,7 @@ static inline CGFloat lerp(CGFloat a, CGFloat b, CGFloat p)
 
 - (id)initInScrollView:(UIScrollView *)scrollView activityIndicatorView:(UIView *)activity
 {
-    self = [super initWithFrame:CGRectMake(0, -(kTotalViewHeight + scrollView.contentInset.top), scrollView.frame.size.width, kTotalViewHeight)];
+    self = [super initWithFrame:CGRectMake(0, -(kTotalViewHeight + scrollView.contentInset.top - kTopOffset), scrollView.frame.size.width, kTotalViewHeight)];
     
     if (self) {
         self.scrollView = scrollView;
@@ -168,7 +169,7 @@ static inline CGFloat lerp(CGFloat a, CGFloat b, CGFloat p)
     if ([keyPath isEqualToString:@"contentInset"]) {
         if (!_ignoreInset) {
             self.originalContentInset = [[change objectForKey:@"new"] UIEdgeInsetsValue];
-            self.frame = CGRectMake(0, -(kTotalViewHeight + self.scrollView.contentInset.top), self.scrollView.frame.size.width, kTotalViewHeight);
+            self.frame = CGRectMake(0, -(kTotalViewHeight + self.scrollView.contentInset.top - kTopOffset), self.scrollView.frame.size.width, kTotalViewHeight);
         }
         return;
     }


### PR DESCRIPTION
I've implemented the ODRefreshControl into an app that uses the "translucent = YES" setting and therefore the content appears unter the header-bar so all views of the navigation-controller start at the very top of the phone and not unter the header bar.

This parameter can be set to the pixel-height of the header (as a custom-solution might have different heights" or to 0 if the header is not translucent.
