### PR TITLE
Fixed a bug with calling beginRefresh and then endRefresh preventing the first manual pull to refresh afterwards.

### DIFF
--- a/ODRefreshControl/ODRefreshControl.m
+++ b/ODRefreshControl/ODRefreshControl.m
@@ -424,7 +424,10 @@ static inline CGFloat lerp(CGFloat a, CGFloat b, CGFloat p)
 - (void)endRefreshing
 {
     if (_refreshing) {
+
         self.refreshing = NO;
+		_canRefresh = YES;
+
         // Create a temporary retain-cycle, so the scrollView won't be released
         // halfway through the end animation.
         // This allows for the refresh control to clean up the observer,


### PR DESCRIPTION
In one of our project we were calling beginRefresh manually and properly paired it with endRefresh. However _canRefresh flag was not set back to YES in endRefresh and this blocked the net manual pull-to-refresh.
